### PR TITLE
Empty::AppendActiveIndices()で、後手の場合にInv(sq)を呼ぶタイミングを修正

### DIFF
--- a/source/eval/nnue/features/empty.cpp
+++ b/source/eval/nnue/features/empty.cpp
@@ -21,9 +21,9 @@ namespace Eval {
 
 				for (int i = 0; i < SQ_NB; i++) {
 					Square sq = static_cast<Square>(i);
-					if (perspective == WHITE)
-						sq = Inv(sq);
 					if (empties & sq) {
+						if (perspective == WHITE)
+							sq = Inv(sq);
 						active->push_back(sq);
 					}
 				}


### PR DESCRIPTION
はじめまして。
NNUEEmptyで、テストコマンド「test nnue test_features」でエラーになってしまうようでしたので修正してみました。
評価関数の全計算と差分計算で結果が異なるようでしたので、全計算の方を修正してみました。